### PR TITLE
Support assigning labels to stack elements

### DIFF
--- a/src/components/ScriptEditor/ScriptEditor.tsx
+++ b/src/components/ScriptEditor/ScriptEditor.tsx
@@ -51,6 +51,13 @@ const ScriptEditor: React.FC<Props> = ({ scriptWiz }) => {
 
   const parseInput = useCallback(
     (inputText: string) => {
+
+      // Look for $label assignments, keep them for later processing and strip them from the line string.
+      const labelMatches = inputText.match(/\$\w+$/)
+      if (labelMatches) {
+        inputText = inputText.replace(/\s*\$\w+$/, '')
+      }
+
       if (inputText.startsWith('<') && inputText.endsWith('>')) {
         const inputTextValue = inputText.substring(1, inputText.length - 1);
 
@@ -74,8 +81,15 @@ const ScriptEditor: React.FC<Props> = ({ scriptWiz }) => {
         }
       } else if (inputText.startsWith('OP_')) {
         scriptWiz.parseOpcode(inputText);
-      } else {
+      } else if (inputText !== '') {
         console.error('UI: Invalid input value!!!');
+      }
+
+      // Assign the label to the last element on the stack
+      if (labelMatches) {
+        if (!scriptWiz.stackDataList.main.length) throw new Error('nothing to label');
+        const lastStack = scriptWiz.stackDataList.main[scriptWiz.stackDataList.main.length-1];
+        lastStack.label = labelMatches[0];
       }
     },
     [scriptWiz],

--- a/src/components/ScriptEditor/ScriptEditorOutput/ScriptEditorOutput.tsx
+++ b/src/components/ScriptEditor/ScriptEditorOutput/ScriptEditorOutput.tsx
@@ -23,9 +23,9 @@ const ScriptEditorOutput: React.FC<Props> = ({ lastStackDataList, lineStackDataL
   };
 
   const getWhisper = useCallback(
-    (key: string, tooltip: string, display: string) => (
+    (key: string, tooltip: string, display: string, label?: string) => (
       <div className="tooltip" key={key}>
-        <div className={`editor-output-text ${getOutputValueType(display)} `}>{display}</div>
+        <div className={`editor-output-text ${getOutputValueType(display)} `}>{label ? <em>{label} </em> : ''}{display}</div>
         <span className="tooltiptext">{'0x' + tooltip}</span>
       </div>
     ),
@@ -41,8 +41,7 @@ const ScriptEditorOutput: React.FC<Props> = ({ lastStackDataList, lineStackDataL
 
         if (stackData.number !== undefined) displayValue = stackData.number.toString();
         else if (stackData.text !== undefined) displayValue = stackData.text;
-
-        return getWhisper(key, stackData.hex, displayValue);
+        return getWhisper(key, stackData.hex, displayValue, stackData.label);
       }),
     [getWhisper],
   );


### PR DESCRIPTION
Using a new `$<label>` syntax, which assigns a label to the last element
on stack. This can be specified on the same line as the push/opcode or
in a standalone line.

This is meant to make it easier to keep track of things while developing
and doesn't have an effect on the generated Script.

Depends on https://github.com/bit-matrix/wiz-data/pull/2 and https://github.com/bit-matrix/script-wiz-lib-core/pull/5.